### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "lovata/oc-shopaholic-plugin",
+    "type": "october-plugin",
+    "description": "eCommerce plugin for October CMS",
+    "license": "GPL-3.0-only",
+    "require": {
+        "php": ">=7.0",
+        "lovata/oc-toolbox-plugin": "~1.15"
+    }
+}


### PR DESCRIPTION
Having a composer package information would help me a lot, since it allows developers to automate the installation of dependencies with deployment tools.

This lets composer to install this package into `plugins/lovata/shopaholic` directory.

This PR should be merged after lovata/oc-toolbox-plugin#46 is merged.

If this repository is not registered in [Packagist](https://packagist.org), following is required in the composer.json file of depending project. Its versions are automatically detected from the tags.

```
    "require": {
        ...
    },
    ...
    "repositories": [
        {
            "url": "https://github.com/lovata/oc-shopaholic-plugin.git",
            "type": "git"
        }
    ]
```

Thanks!