### PR TITLE
Add extensibility to control visibility in serialized data

### DIFF
--- a/models/Brand.php
+++ b/models/Brand.php
@@ -125,6 +125,8 @@ class Brand extends ImportModel
         'images',
     ];
 
+    public $hidden = [];
+
     /**
      * Before validate event handler
      */

--- a/models/Brand.php
+++ b/models/Brand.php
@@ -125,6 +125,7 @@ class Brand extends ImportModel
         'images',
     ];
 
+    public $visible = [];
     public $hidden = [];
 
     /**

--- a/models/Category.php
+++ b/models/Category.php
@@ -149,6 +149,7 @@ class Category extends ImportModel
     public $dates = ['created_at', 'updated_at'];
     public $casts = [];
 
+    public $visible = [];
     public $hidden = [];
 
     /**

--- a/models/Category.php
+++ b/models/Category.php
@@ -149,6 +149,8 @@ class Category extends ImportModel
     public $dates = ['created_at', 'updated_at'];
     public $casts = [];
 
+    public $hidden = [];
+
     /**
      * Before validate event handler
      */

--- a/models/Offer.php
+++ b/models/Offer.php
@@ -151,6 +151,7 @@ class Offer extends ImportModel
 
     public $arPriceField = ['price', 'old_price'];
 
+    public $visible = [];
     public $hidden = [];
 
     /**

--- a/models/Offer.php
+++ b/models/Offer.php
@@ -151,6 +151,8 @@ class Offer extends ImportModel
 
     public $arPriceField = ['price', 'old_price'];
 
+    public $hidden = [];
+
     /**
      * Set quantity attribute value
      * @param  int $iQuantity

--- a/models/Product.php
+++ b/models/Product.php
@@ -187,6 +187,7 @@ class Product extends ImportModel
 
     public $jsonable = [];
 
+    public $visible = [];
     public $hidden = [];
 
     /**

--- a/models/Product.php
+++ b/models/Product.php
@@ -187,6 +187,8 @@ class Product extends ImportModel
 
     public $jsonable = [];
 
+    public $hidden = [];
+
     /**
      * Get element by brand ID
      * @param Product $obQuery


### PR DESCRIPTION
Adding `$visible` and `$hidden` array fields to models allows us to limit fields to be included when the model data is serialized, such as by `$model->toJson()`.

These fields are explained in [the official document](https://octobercms.com/docs/database/serialization#hiding-attributes-from-json).

For example, below would exclude `description` field from serializing Product model data.

```
Product::extend(function(Product $model) {
    $model->hidden[] = 'description';
});
```