### PR TITLE
[FIX] correct promo block ACL

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -38,7 +38,7 @@ navigation:
         url: lovata/shopaholic/promoblocks
         icon: oc-icon-money
         permissions:
-            - 'shopaholic-menu-promo'
+            - 'shopaholic-menu-promo-block'
         sideMenu:
             shopaholic-menu-promo-block:
                 label: 'lovata.shopaholic::lang.menu.promo_block'


### PR DESCRIPTION
Fixes #133

non-superusers were not abled to access the promo-block menu. now they hopefully will