### PR TITLE
Fixed sorting by price based on the type of price.

### DIFF
--- a/classes/store/offer/SortingListStore.php
+++ b/classes/store/offer/SortingListStore.php
@@ -32,9 +32,9 @@ class SortingListStore extends AbstractStoreWithParam
             $arElementIDList = $this->getNewOfferList();
         } elseif ($this->sValue == OfferListStore::SORT_NO) {
             $arElementIDList = $this->getOfferList();
-        } elseif (preg_match('%^'.OfferListStore::SORT_PRICE_ASC.'\|.+%', $this->sValue)) {
+        } elseif (strpos($this->sValue, OfferListStore::SORT_PRICE_ASC) !== false) {
             $arElementIDList = $this->getByPriceTypeASC();
-        } elseif (preg_match('%^'.OfferListStore::SORT_PRICE_DESC.'\|.+%', $this->sValue)) {
+        } elseif (strpos($this->sValue, OfferListStore::SORT_PRICE_DESC) !== false) {
             $arElementIDList = $this->getByPriceTypeDESC();
         } else {
             $arElementIDList = $this->getCustomSortingList();

--- a/classes/store/product/SortingListStore.php
+++ b/classes/store/product/SortingListStore.php
@@ -32,9 +32,9 @@ class SortingListStore extends AbstractStoreWithParam
             $arElementIDList = $this->getNewProductList();
         } elseif ($this->sValue == ProductListStore::SORT_NO) {
             $arElementIDList = $this->getProductList();
-        } elseif (preg_match('%^'.ProductListStore::SORT_PRICE_ASC.'\|.+%', $this->sValue)) {
+        } elseif (strpos($this->sValue, ProductListStore::SORT_PRICE_ASC) !== false) {
             $arElementIDList = $this->getByPriceTypeASC();
-        } elseif (preg_match('%^'.ProductListStore::SORT_PRICE_DESC.'\|.+%', $this->sValue)) {
+        } elseif (strpos($this->sValue, ProductListStore::SORT_PRICE_DESC) !== false) {
             $arElementIDList = $this->getByPriceTypeDESC();
         } else {
             $arElementIDList = $this->getCustomSortingList();

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -154,3 +154,5 @@
     - update_table_offers_add_sorting_field.php
 1.32.1:
     - 'Updated composer file'
+1.32.2:
+    - 'Fixed sorting by price based on the type of price. Thanks for contribution dblackCat'


### PR DESCRIPTION
On my site with a large number of price types, sorting by price based on the type of price did not work.

I noticed that when selecting the sort products.sort('price|asc|tomsk'), the sorting works, but when selecting products.sort('price|desc|tomsk') later, nothing changed. It turned out that the regular expression was working incorrectly and in the if comparison blocks, when sorting with the desc type, it worked out the condition for asc.

Solved the problem via strpos for product and offer stores.